### PR TITLE
include direct plus loans in the total

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "student-debt-calc",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Student debt calculator",
   "main": "src/index.js",
   "scripts": {

--- a/src/loans/index.js
+++ b/src/loans/index.js
@@ -39,6 +39,7 @@ function loanTotals( data ) {
   data.federalTotal = data.perkins +
                       data.staffSubsidized +
                       data.staffUnsubsidized +
+                      data.directPlus +
                       data.gradplus;
 
   // gap


### PR DESCRIPTION
This adds direct plus loans to the federal loan total. Note that it _does not_ enforce ranges or anything else for these loans, but just adds them to the sum.
## Review

@mistergone or @higs4281
