### PR TITLE
Added independent deferral period to each loan in privateLoanMulti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 0.1.1 2016-01-08
+- added deferPeriod to privateLoanMulti (each private loan can have an individual deferral period)
+
 ## 0.1.0 2016-01-08
 - added handling for multiple private loans array (data.privateLoanMulti)
 - added test for multiple private loans

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ These values are deducted from cost of attendance.
 |-----|-----|-----|-----|
 |`financials.institutionalLoanRate` | number | Loan rate on institutional loan, expressed as a decimal | 0.079 |
 |`financials.privateLoan` | number | Amount of private loan | 0 |
-|`financials.privateLoanMulti`| Array | Used for multiple private loans. This array should contain objects, with each object having two properties - `amount` for the amount of the loan, and `rate` for the loan's rate expressed as a decimal. Example: `[ { 'amount': 3000, 'rate': 0.061 }, { 'amount': 3600, 'rate': 0.059 } ]` __Important note:__ If `privateLoanMulti` is not empty, then the values of `privateLoanMulti` are used and the value of `privateLoan` is ignored! | `[]` (empty array) |
+|`financials.privateLoanMulti`| Array | Used for multiple private loans. This array should contain objects, with each object having two properties - `amount` for the amount of the loan, `rate` for the loan's rate expressed as a decimal, and `deferPeriod` for the number of months the loan is deferred. Example: `[ { 'amount': 3000, 'rate': 0.061, 'deferPeriod': 6 }, { 'amount': 3600, 'rate': 0.059, 'deferPeriod': 6 } ]` __Important note:__ If `privateLoanMulti` is not empty, then the values of `privateLoanMulti` are used and the value of `privateLoan` is ignored! | `[]` (empty array) |
 |`financials.homeEquity` | number | Amount of home equity loan | 0 |
 
 #### Loan rates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "student-debt-calc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Student debt calculator",
   "main": "src/index.js",
   "scripts": {

--- a/src/debt-total.js
+++ b/src/debt-total.js
@@ -67,7 +67,7 @@ function debtTotal( data ) {
     for ( var x = 0; x < multiLength; x++ ) {
       var loan = data.privateLoanMulti[x],
           debt = calcDebt( loan.amount,
-            loan.rate, data.programLength, data.deferPeriod );
+            loan.rate, data.programLength, loan.deferPeriod );
       data.privateLoanTotal += debt;
     }
   } else {

--- a/test/debt-total-spec.js
+++ b/test/debt-total-spec.js
@@ -16,9 +16,9 @@ describe( 'calculates debt totals', function() {
 
   it ( 'handles multiple private loans', function() {
     data.privateLoanMulti = [
-        { 'amount': 2000, 'rate': .079 },
-        { 'amount': 3000, 'rate': .061 },
-        { 'amount': 4000, 'rate': .041 }
+        { 'amount': 2000, 'rate': .079, 'deferPeriod': 6 },
+        { 'amount': 3000, 'rate': .061, 'deferPeriod': 6 },
+        { 'amount': 4000, 'rate': .041, 'deferPeriod': 6 }
       ];
     debtTotal( data );
     expect( data.privateLoanTotal ).to.equal( 9896 + 14196 + 17968 );


### PR DESCRIPTION
Since our interface allows each loan to have its own deferral period, it seemed like a good idea to make this code capable of doing that.
## Additions
- added deferPeriod to privateLoanMulti (each private loan can have an individual deferral period)
## Review
- @ascott1, if you please!
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
