### PR TITLE
Various loan fixes and changes, update to version 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 2.2.2 2016-02-19
+- Further fix to private loan monthly payments and lifetime oan value
+
+## 2.2.1 2016-02-18
+- Fix for private loan total debt bug
+
+## 2.2.0 2016-02-18
+- Institutional loans no longer accrue debt during program
+
+## 2.1.1 2016-02-16
+- Fix for monthly loan payment and lifetime loan value,
+
 ## 2.1.0 2016-02-09
 - Added support for fees on multiple Private Loans (no legacy support for single private loan)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "student-debt-calc",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Student debt calculator",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "student-debt-calc",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Student debt calculator",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "student-debt-calc",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Student debt calculator",
   "main": "src/index.js",
   "scripts": {

--- a/src/debt-total.js
+++ b/src/debt-total.js
@@ -72,6 +72,7 @@ function debtTotal( data ) {
         amount = loan.amount + ( loan.amount * loan.fees );
       }
       debt = calcDebt( amount, loan.rate, data.programLength, loan.deferPeriod );
+      data.privateLoanMulti[x].totalDebt = debt;
       data.privateLoanDebt += debt;
     }
   } else {

--- a/src/debt-total.js
+++ b/src/debt-total.js
@@ -81,8 +81,7 @@ function debtTotal( data ) {
   }
 
   // Institutional Loan debt at graduation
-  data.institutionalLoanDebt = calcDebt( data.institutionalLoan,
-    data.institutionalLoanRate, data.programLength, data.deferPeriod );
+  data.institutionalLoanDebt = data.institutionalLoan * data.programLength;
 
   // Home Equity Loans at graduation
   data.homeEquityDebt = data.homeEquity * data.homeEquityLoanRate / 12 *

--- a/src/payment.js
+++ b/src/payment.js
@@ -17,7 +17,7 @@ function payment( data ) {
   if ( data.privateLoanMulti.length !== 0 ) {
     for ( var x = 0; x < data.privateLoanMulti.length; x++ ) {
       var privLoan = data.privateLoanMulti[x],
-          total = privLoan.amount * privLoan.fees;
+          total = privLoan.amount + privLoan.amount * privLoan.fees;
       data.loanMonthly += total * ( privLoan.rate / 12 ) / ( 1 - Math.pow( 1 + privLoan.rate / 12, -data.repaymentTerm * 12 ) );
     }
   } else {

--- a/src/payment.js
+++ b/src/payment.js
@@ -16,12 +16,11 @@ function payment( data ) {
   // Private Loan handler
   if ( data.privateLoanMulti.length !== 0 ) {
     for ( var x = 0; x < data.privateLoanMulti.length; x++ ) {
-      var privLoan = data.privateLoanMulti[x],
-          total = privLoan.amount + privLoan.amount * privLoan.fees;
-      data.loanMonthly += total * ( privLoan.rate / 12 ) / ( 1 - Math.pow( 1 + privLoan.rate / 12, -data.repaymentTerm * 12 ) );
+      var privLoan = data.privateLoanMulti[x];
+      data.loanMonthly += privLoan.totalDebt * ( privLoan.rate / 12 ) / ( 1 - Math.pow( 1 + privLoan.rate / 12, -data.repaymentTerm * 12 ) );
     }
   } else {
-    data.loanMonthly += data.privateLoanTotal * ( data.privateLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.privateLoanRate / 12, -data.repaymentTerm * 12 ) );
+    data.loanMonthly += data.privateLoanDebt * ( data.privateLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.privateLoanRate / 12, -data.repaymentTerm * 12 ) );
   }
 
   // loanMonthlyparent

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -45,7 +45,7 @@ describe( 'overall debt calculations', function() {
   it( '...calculates institutional loans.', function() {
     financials.privateLoan = 0;
     financials.institutionalLoan = 13750;
-    expect( debtCalc( financials ).totalDebt ).to.equal( 68035 );
+    expect( debtCalc( financials ).totalDebt ).to.equal( 55000 );
   });
 
   it( '...calculates Perkins loans.', function() {
@@ -91,7 +91,7 @@ describe( 'overall debt calculations', function() {
     financials.directUnsubsidized = 3000;
     financials.institutionalLoan = 1500;
     financials.privateLoan = 2500;
-    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 45702 );
+    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 44280 );
   });
 
   it( '...properly calculates remainingCost.', function() {


### PR DESCRIPTION
This PR brings the main repo up to date with my work (version 2.2.2), and encompasses fixes and changes to various loans and debt totals. Sorry for the mess I made of the ordering of commits and such!
## Changes
- Fixes to private loan monthly payments and lifetime loan value
- Fix for private loan total debt bug
- Institutional Loan no longer accrues interest during program
## Testing
- `mocha test/` runs the automated tests - feel free to suggest new tests!
## Review
- @ascott1! And @marteki and @niqjohnson, if you have the time!
## Checklist
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged
- [ ] Visually tested in supported browsers and devices 
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated GIF

We're all up to date now!

![it-crowd-claps](https://cloud.githubusercontent.com/assets/1490703/13357597/23118d60-dc79-11e5-9cd7-719125872c1e.gif)
