### PR TITLE
Error reporting added!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## Unreleased
+- Added error handling for various loan and grant limits
+
 ## 2.2.2 2016-02-19
 - Further fix to private loan monthly payments and lifetime oan value
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "student-debt-calc",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Student debt calculator",
   "main": "src/index.js",
   "scripts": {

--- a/src/default-values.js
+++ b/src/default-values.js
@@ -37,6 +37,8 @@ module.exports = {
   // Pell grant settings
   pellMax: 0,
   pellCap: 5730,
+  // Military Tuition Assistance settings
+  militaryAssistanceCap: 4500,
   // Perkins loan settings
   perkinsUnderCap: 5500,
   perkinsGradCap: 8000,

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,9 @@ function studentDebtCalculator( financials ) {
   // merge financials into defaults to create data
   data = merge( defaults, financials );
 
+  // reset errors
+  data.errors = {};
+
   // set rate values
   rates.inState( data );
   rates.unsubsidized( data );

--- a/src/loans/direct-subsidized.js
+++ b/src/loans/direct-subsidized.js
@@ -28,7 +28,6 @@ function subDirect( data ) {
   if ( data.directSubsidized > data.yearOneCosts - data.pell - data.perkins ) {
     data.errors.subsidizedOverCost = 'Direct subsidized loans exceed cost of attendance.';
   }
-  console.log( data.directSubsidizedMax );
   if ( data.directSubsidized > data.directSubsidizedMax ) {
     data.errors.subsidizedOverCap = 'Direct subsidized loans exceed federal limit of ' +
       data.directSubsidizedMax + '.';

--- a/src/loans/direct-subsidized.js
+++ b/src/loans/direct-subsidized.js
@@ -18,14 +18,32 @@ function subDirect( data ) {
   if ( data.undergrad === false ) {
     data.directSubsidizedMax = 0;
   } else {
-    data.directSubsidizedMax = data.yearOneCosts - data.pell - data.perkins;
     data.directSubsidizedMax = calculateMaxRange( year, data );
+  }
+
+  // Error handling
+  if ( data.directSubsidized > 0 && data.undergrad === false ) {
+    data.errors.subsidizedNoGrad = 'Direct subsidized loans are available only to undergraduate students.';
+  }
+  if ( data.directSubsidized > data.yearOneCosts - data.pell - data.perkins ) {
+    data.errors.subsidizedOverCost = 'Direct subsidized loans exceed cost of attendance.';
+  }
+  console.log( data.directSubsidizedMax );
+  if ( data.directSubsidized > data.directSubsidizedMax ) {
+    data.errors.subsidizedOverCap = 'Direct subsidized loans exceed federal limit of ' +
+      data.directSubsidizedMax + '.';
   }
 
   data.directSubsidized = enforceRange(
     data.directSubsidized,
     0,
     data.directSubsidizedMax
+  );
+
+  data.directSubsidized = enforceRange(
+    data.directSubsidized,
+    0,
+    data.yearOneCosts - data.pell - data.perkins
   );
 
   return data;
@@ -38,7 +56,7 @@ function subDirect( data ) {
  * @returns { number } range enforced number
  */
 function calculateMaxRange( year, data ) {
-  var range = data.directSubsidizedMax;
+  var range = 0;
   if ( year === 1 ) {
     range = data.subsidizedCapYearOne;
   }
@@ -48,12 +66,7 @@ function calculateMaxRange( year, data ) {
   if ( year === 3 ) {
     range = data.subsidizedCapYearThree - data.directSubsidized;
   }
-  return enforceRange(
-    data.directSubsidizedMax,
-    0,
-    range
-  );
-
+  return range;
 }
 
 module.exports = subDirect;

--- a/src/loans/direct-unsubsidized.js
+++ b/src/loans/direct-unsubsidized.js
@@ -10,6 +10,10 @@ var unsubMax = {};
  * @returns { object } the data object with perkins data added
  */
 function unsubDirect( data ) {
+  var costMax = data.yearOneCosts -
+                 data.pell -
+                 data.perkins -
+                 data.directSubsidized;
   // unsubsidized loan max for independent students
   unsubMax.independent( data );
   // unsubsidized loan max for dependent students
@@ -23,6 +27,16 @@ function unsubDirect( data ) {
 
   data.directUnsubsidizedMax = enforceRange(
     data.directUnsubsidizedMax, 0, false );
+
+  // error handling
+  if ( data.directUnsubsidized > costMax ) {
+    data.errors.unsubsidizedOverCost = 'Direct unsubsidized loans exceed cost of attendance.';
+  }
+  if ( data.directUnsubsidized > data.directUnsubsidizedMax ) {
+    data.errors.unsubsidizedOverCap = 'Direct unsubsidized loans exceed federal limit of ' +
+      data.directUnsubsidizedMax + '.';
+  }
+
   data.directUnsubsidized = enforceRange(
     data.directUnsubsidized, 0, data.directUnsubsidizedMax );
 

--- a/src/loans/perkins.js
+++ b/src/loans/perkins.js
@@ -9,9 +9,15 @@ var enforceRange = require( '../utils/enforce-range' );
   */
 function perkins( data ) {
   data.perkinsMax = data.yearOneCosts - data.pell;
+  if ( data.perkins > data.perkinsMax ) {
+    data.errors.perkinsOverCost = 'Perkins loan exceeded cost of attendance.';
+  }
   data.perkinsMax = enforceRange( data.perkinsMax, 0, data.perkinsUnderCap );
   if ( data.undergrad !== true ) {
     data.perkinsMax = enforceRange( data.perkinsMax, 0, data.perkinsGradCap );
+  }
+  if ( data.perkins > data.perkinsMax ) {
+    data.errors.perkinsOverMax = 'Perkins loan exceeded federal limit of ' + data.perkinsMax + '.';
   }
   data.perkins = enforceRange( data.perkins, 0, data.perkinsMax );
 

--- a/src/loans/perkins.js
+++ b/src/loans/perkins.js
@@ -17,7 +17,7 @@ function perkins( data ) {
     data.perkinsMax = enforceRange( data.perkinsMax, 0, data.perkinsGradCap );
   }
   if ( data.perkins > data.perkinsMax ) {
-    data.errors.perkinsOverMax = 'Perkins loan exceeded federal limit of ' + data.perkinsMax + '.';
+    data.errors.perkinsOverCap = 'Perkins loan exceeded federal limit of ' + data.perkinsMax + '.';
   }
   data.perkins = enforceRange( data.perkins, 0, data.perkinsMax );
 

--- a/src/scholarship.js
+++ b/src/scholarship.js
@@ -14,6 +14,9 @@ function scholarships( data ) {
     data.pellMax = data.pellCap;
   }
   // enforce limits on Pell grants
+  if ( data.pellMax > data.yearOneCosts ) {
+    data.errors.pellOverCosts = 'The Pell grant exceeds the cost of attendance.';
+  }
   data.pellMax = enforceRange( data.pellMax, 0, data.yearOneCosts );
   data.pell = enforceRange( data.pell, 0, data.pellMax );
 

--- a/src/scholarship.js
+++ b/src/scholarship.js
@@ -20,9 +20,19 @@ function scholarships( data ) {
   data.pellMax = enforceRange( data.pellMax, 0, data.yearOneCosts );
   
   if ( data.pell > data.pellMax ) {
-    data.errors.pellOverMax = 'The Pell grant exceeds the Pell maximum.';
+    data.errors.pellOverCap = 'The Pell grant exceeds the federal limit of ' + 
+    data.pellCap + '.';
   }
   data.pell = enforceRange( data.pell, 0, data.pellMax );
+
+  // enoforce limits on Military Tuition Assistance
+  if ( data.militaryTuitionAssistance > data.militaryAssistanceCap ) {
+    data.errors.mtaOverCap =
+      'Military Tuition Assistance exceeds the federal limit of ' +
+      data.militaryAssistanceCap + '.'
+  }
+  data.militaryTuitionAssistance = enforceRange(
+    data.militaryTuitionAssistance, 0, data.militaryAssistanceCap );
 
   // Total Grants
   data.grantsTotal = data.pell + data.scholarships +

--- a/src/scholarship.js
+++ b/src/scholarship.js
@@ -14,10 +14,14 @@ function scholarships( data ) {
     data.pellMax = data.pellCap;
   }
   // enforce limits on Pell grants
-  if ( data.pellMax > data.yearOneCosts ) {
+  if ( data.pell > data.yearOneCosts ) {
     data.errors.pellOverCosts = 'The Pell grant exceeds the cost of attendance.';
   }
   data.pellMax = enforceRange( data.pellMax, 0, data.yearOneCosts );
+  
+  if ( data.pell > data.pellMax ) {
+    data.errors.pellOverMax = 'The Pell grant exceeds the Pell maximum.';
+  }
   data.pell = enforceRange( data.pell, 0, data.pellMax );
 
   // Total Grants

--- a/src/scholarship.js
+++ b/src/scholarship.js
@@ -18,9 +18,9 @@ function scholarships( data ) {
     data.errors.pellOverCosts = 'The Pell grant exceeds the cost of attendance.';
   }
   data.pellMax = enforceRange( data.pellMax, 0, data.yearOneCosts );
-  
+
   if ( data.pell > data.pellMax ) {
-    data.errors.pellOverCap = 'The Pell grant exceeds the federal limit of ' + 
+    data.errors.pellOverCap = 'The Pell grant exceeds the federal limit of ' +
     data.pellCap + '.';
   }
   data.pell = enforceRange( data.pell, 0, data.pellMax );
@@ -29,7 +29,7 @@ function scholarships( data ) {
   if ( data.militaryTuitionAssistance > data.militaryAssistanceCap ) {
     data.errors.mtaOverCap =
       'Military Tuition Assistance exceeds the federal limit of ' +
-      data.militaryAssistanceCap + '.'
+      data.militaryAssistanceCap + '.';
   }
   data.militaryTuitionAssistance = enforceRange(
     data.militaryTuitionAssistance, 0, data.militaryAssistanceCap );

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -44,7 +44,6 @@ describe( 'overall debt calculations', function() {
   });
 
   it( '...calculates institutional loans.', function() {
-    console.log( financials );
     financials.privateLoan = 0;
     financials.institutionalLoan = 13750;
     expect( debtCalc( financials ).totalDebt ).to.equal( 55000 );

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -11,6 +11,7 @@ describe( 'overall debt calculations', function() {
     transportation: 500,
     otherExpenses: 250,
     scholarships: 0,
+    militaryTuitionAssistance: 0,
     pell: 0,
     savings: 0,
     family: 0,

--- a/test/loans-sub-direct.spec.js
+++ b/test/loans-sub-direct.spec.js
@@ -16,7 +16,7 @@ describe( 'sets subsidized Stafford loan values', function() {
   it( 'sets the subsidized max for undergrad students in year 2', function() {
     data.undergrad = true;
     data.yearInCollege = 2;
-    var expectedMax = data.yearOneCosts - data.perkins - data.pell;
+    var expectedMax = data.subsidizedCapYearTwo - data.directSubsidized;
     subDirect( data );
     expect( data.directSubsidizedMax ).to.equal( expectedMax );
   });
@@ -24,7 +24,7 @@ describe( 'sets subsidized Stafford loan values', function() {
   it( 'sets the subsidized max for undergrad students in year 3', function() {
     data.undergrad = true;
     data.yearInCollege = 3;
-    var expectedMax = data.yearOneCosts - data.perkins - data.pell;
+    var expectedMax = data.subsidizedCapYearThree - data.directSubsidized;
     subDirect( data );
     expect( data.directSubsidizedMax ).to.equal( expectedMax );
   });


### PR DESCRIPTION
This PR adds error handling. Now, when numbers exceed limits, the object returned by `student-debt-calc` contains an error property, which is itself an object full of error keys and messages.
## Additions
- `financials` object returned by this package has an `errors` property (an Object). The `errors` Object starts off empty, and as errors occur, it is populated with keys (error codes) and values (error messages). For instance, if the passed values represent a Pell grant that exceeds a federal limit of $5,750, the `errors` object would be: `{ 'pellOverCap': 'The Pell grant exceeds the federal limit of 5750.' }`. In this way, an app developer can check to see if the error code is an extant property of the `errors` Object (e.g. `financials.errors.hasOwnProperty( 'someErrorCode' )` ), and can use the default error message if they wish.
## Changes
- Some aspects of the code were altered slightly to make error reporting more simple.
## Testing
- `mocha test/` runs our suite of tests, including 9 new tests for error reporting.
## Review
- @ascott1, if you have the time!
- @marteki, @niqjohnson, check it out!
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated GIF

![liz-lemon-speak-to-pizza](https://cloud.githubusercontent.com/assets/1490703/13440465/2b354aaa-dfc0-11e5-8241-8556311b2280.gif)
