### PR TITLE
Mutiple loan values added based on loan term.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## Unreleased
+## 2.4.0
+- Added the tenYear and twentyYear properties to the returned object
 - Added error handling for various loan and grant limits
 
 ## 2.2.2 2016-02-19

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "homepage": "https://github.com/cfpb/student-debt-calc#readme",
   "dependencies": {
-    "extend": "^3.0.0"
+    "extend": "^3.0.0",
+    "nyc": "^4.0.1"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "student-debt-calc",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Student debt calculator",
   "main": "src/index.js",
   "scripts": {

--- a/src/payment.js
+++ b/src/payment.js
@@ -5,32 +5,65 @@
   * @param { object } data - the data object
   * @returns { object } the data object with monthly and total payments
   */
-function payment( data ) {
-  // loanMonthly - "Monthly Payments"
-  data.loanMonthly = data.perkinsDebt * ( data.perkinsRate / 12 ) / ( 1 - Math.pow( 1 + data.perkinsRate / 12, -data.repaymentTerm * 12 ) ) +
-  data.directSubsidizedDebt * ( data.subsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.subsidizedRate / 12, -data.repaymentTerm * 12 ) ) +
-  data.directUnsubsidizedDebt * ( data.unsubsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.unsubsidizedRate / 12, -data.repaymentTerm * 12 ) ) +
-  data.gradPlusDebt * ( data.gradPlusRate / 12 ) / ( 1 - Math.pow( 1 + data.gradPlusRate / 12, -data.repaymentTerm * 12 ) ) +
-  data.institutionalLoanDebt * ( data.institutionalLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.institutionalLoanRate / 12, -data.repaymentTerm * 12 ) );
 
-  // Private Loan handler
-  if ( data.privateLoanMulti.length !== 0 ) {
-    for ( var x = 0; x < data.privateLoanMulti.length; x++ ) {
-      var privLoan = data.privateLoanMulti[x];
-      data.loanMonthly += privLoan.totalDebt * ( privLoan.rate / 12 ) / ( 1 - Math.pow( 1 + privLoan.rate / 12, -data.repaymentTerm * 12 ) );
+var payment = {
+
+  calculateMonthly: function( data, repaymentTerm ) {
+    // loanMonthly - "Monthly Payments"
+    var loanMonthly = data.perkinsDebt * ( data.perkinsRate / 12 ) / ( 1 - Math.pow( 1 + data.perkinsRate / 12, -repaymentTerm * 12 ) ) +
+      data.directSubsidizedDebt * ( data.subsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.subsidizedRate / 12, -repaymentTerm * 12 ) ) +
+      data.directUnsubsidizedDebt * ( data.unsubsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.unsubsidizedRate / 12, -repaymentTerm * 12 ) ) +
+      data.gradPlusDebt * ( data.gradPlusRate / 12 ) / ( 1 - Math.pow( 1 + data.gradPlusRate / 12, -repaymentTerm * 12 ) ) +
+      data.institutionalLoanDebt * ( data.institutionalLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.institutionalLoanRate / 12, -repaymentTerm * 12 ) );
+
+    // Private Loan handler
+    if ( data.privateLoanMulti.length !== 0 ) {
+      for ( var x = 0; x < data.privateLoanMulti.length; x++ ) {
+        var privLoan = data.privateLoanMulti[x];
+        loanMonthly += privLoan.totalDebt * ( privLoan.rate / 12 ) / ( 1 - Math.pow( 1 + privLoan.rate / 12, -repaymentTerm * 12 ) );
+      }
+    } else {
+      loanMonthly += data.privateLoanDebt * ( data.privateLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.privateLoanRate / 12, -repaymentTerm * 12 ) );
     }
-  } else {
-    data.loanMonthly += data.privateLoanDebt * ( data.privateLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.privateLoanRate / 12, -data.repaymentTerm * 12 ) );
+    return loanMonthly;
+  },
+
+  calculateLifetime: function( data, repaymentTerm ) {
+    // loanLifetime
+    var loanLifetime = data.loanMonthly * repaymentTerm * 12;
+    return loanLifetime;
+  },
+
+  calculateParentMonthly: function( data, repaymentTerm ) {
+    // loanMonthlyparent
+    var loanMonthlyparent = data.parentPlus * ( data.parentPlusRate / 12 ) /
+        Math.pow( 1 - ( 1 + data.parentPlusRate / 12 ), -repaymentTerm * 12 ) +
+        data.homeEquity * ( data.homeEquityLoanRate / 12 ) /
+        Math.pow( 1 - ( 1 + data.homeEquityLoanRate / 12 ), -repaymentTerm * 12 );
+    return loanMonthlyparent;
+  },
+
+  payment: function( data ) {
+    // Calculate based on data.repaymentTerm field (legacy support)
+    data.loanMonthly = payment.calculateMonthly( data, data.repaymentTerm );
+    data.loanLifetime = payment.calculateLifetime( data, data.repaymentTerm );
+    data.loanMonthlyparent = payment.calculateParentMonthly( data, data.repaymentTerm );
+
+    // Calculate 10 year values
+    data.tenYear = {};
+    data.tenYear.loanMonthly = payment.calculateMonthly( data, 10 );
+    data.tenYear.loanLifetime = payment.calculateLifetime( data, 10 );
+    data.tenYear.loanMonthlyparent = payment.calculateParentMonthly( data, 10 );
+
+    // Calculate 20 year values
+    data.twentyYear = {};
+    data.twentyYear.loanMonthly = payment.calculateMonthly( data, 20 );
+    data.twentyYear.loanLifetime = payment.calculateLifetime( data, 20 );
+    data.twentyYear.loanMonthlyparent = payment.calculateParentMonthly( data, 20 );
+
+    return data;
   }
 
-  // loanMonthlyparent
-  data.loanMonthlyparent = data.parentPlus * ( data.parentPlusRate / 12 ) / Math.pow( 1 - ( 1 + data.parentPlusRate / 12 ), -data.repaymentTerm * 12 ) +
-      data.homeEquity * ( data.homeEquityLoanRate / 12 ) / Math.pow( 1 - ( 1 + data.homeEquityLoanRate / 12 ), -data.repaymentTerm * 12 );
-
-  // loanLifetime
-  data.loanLifetime = data.loanMonthly * data.repaymentTerm * 12;
-
-  return data;
 }
 
-module.exports = payment;
+module.exports = payment.payment;

--- a/src/payment.js
+++ b/src/payment.js
@@ -64,6 +64,6 @@ var payment = {
     return data;
   }
 
-}
+};
 
 module.exports = payment.payment;


### PR DESCRIPTION
This PR adds outputs that reflect 10 and 20 year loan values. This will make it easier for applications to compare the two without running this package multiple times. This updates the version to `2.4.0` - this change shouldn't break any existing implementations of the code.

This also fixes `npm test` by adding `nyc` to the package.json dev dependencies.
## Additions
- The returned Object has two new properties, `tenYear` and `twentyYear`, which themselves are Objects containing their own values like `loanLifetime` and `loanMonthly`
- Adds `nyc` for test coverage
## Testing
- Pull it down, run `npm install`, and check it out. The `test/payment-spec.js` file contains new `expect()` functions that check the new values.
- `npm install` is necessary to make `npm test` work properly.
## Review
- @ascott1 (if you have time), @marteki, @higs4281,@niqjohnson - feel free to contact me to walk you through it!
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated GIF

![liz-lemon-self-high5](https://cloud.githubusercontent.com/assets/1490703/15291693/3b5becf4-1b4d-11e6-9686-cb763dd57899.gif)
