### PR TITLE
Change to calculations involving fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## Unreleased
+## 2.3.1 2016-05-17
 - Updated federal interest rates
 - Added error handling for various loan and grant limits
+- Changed federal loan calculations to remove fees from loan total
 
 ## 2.2.2 2016-02-19
 - Further fix to private loan monthly payments and lifetime oan value

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "student-debt-calc",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Student debt calculator",
   "main": "src/index.js",
   "scripts": {

--- a/src/debt-total.js
+++ b/src/debt-total.js
@@ -23,42 +23,28 @@ function debtTotal( data ) {
   // Perkins debt at graduation
   data.perkinsDebt = data.perkins * data.programLength;
 
-  // Direct Subsidized Loan with 1% Origination Fee
-  data.directSubsidizedWithFee = data.directSubsidized *
-                                data.DLOriginationFee;
-
   // Subsidized debt at graduation
-  data.directSubsidizedDebt = data.directSubsidizedWithFee *
+  data.directSubsidizedDebt = data.directSubsidized *
                               data.programLength;
-
-  // Direct Unsubsidized Loan with 1% Origination Fee
-  data.directUnsubsidizedWithFee = data.directUnsubsidized *
-                                  data.DLOriginationFee;
 
   // Unsubsidized debt at graduation
   data.directUnsubsidizedDebt = calcDebt(
-    data.directUnsubsidizedWithFee,
+    data.directUnsubsidized,
     data.unsubsidizedRate,
     data.programLength,
     data.deferPeriod
   );
 
-  // Grad Plus with origination
-  data.gradPlusWithFee = data.gradPlus * data.plusOriginationFee;
-
   // Grad Plus debt at graduation
   data.gradPlusDebt = calcDebt(
-    data.gradPlusWithFee,
+    data.gradPlus,
     data.gradPlusRate,
     data.programLength,
     data.deferPeriod
   );
 
-  // Parent Plus Loans with origination fees
-  data.parentPlusWithFee = data.parentPlus * data.plusOriginationFee;
-
   // Parent Plus Loans at graduation
-  data.parentPlusDebt = data.parentPlusWithFee * data.programLength;
+  data.parentPlusDebt = data.parentPlus * data.programLength;
 
   // Private Loan debt at graduation
   if ( multiLength > 0 ) {

--- a/test/error-spec.js
+++ b/test/error-spec.js
@@ -1,0 +1,93 @@
+var debtCalc = require('../src/index.js');
+
+var chai = require('chai');
+var expect = chai.expect;
+
+describe( 'error reporting', function() {
+  var financials = {
+    tuitionFees: 1,
+    roomBoard: 0,
+    books: 0,
+    transportation: 0,
+    otherExpenses: 0,
+    scholarships: 0,
+    pell: 0,
+    savings: 0,
+    family: 0,
+    perkins: 0,
+    directSubsidized: 0,
+    directUnsubsidized: 0,
+    institutionalLoan: 0,
+    privateLoan: 0,
+    undergrad: true,
+    // specify grant & loan data for testing use
+    institutionalLoanRate: 0.079,
+    privateLoanRate: 0.079,
+    pell: 2,
+    pellCap: 5730,
+    perkinsRate: 0.05,
+    perkinsUnderCap: 5500,
+    perkinsGradCap: 8000,
+    militaryAssistanceCap: 4500,
+    subsidizedRate: 0.0466,
+    unsubsidizedRateUndergrad: 0.0466,
+    unsubsidizedRateGrad: 0.0621,
+    DLOriginationFee: 1.01073,
+    gradPlusRate: 0.0721,
+    parentPlusRate: 0.0721,
+    plusOriginationFee: 1.04292,
+    homeEquityLoanRate: 0.079,
+    privateLoanMulti: [],
+    programLength: 4
+  };
+
+  it( '...reports an error when Pell grants exceed costs.', function() {
+    expect( debtCalc( financials ).errors ).property( 'pellOverCosts' );
+  });
+
+  it( '...reports an error when Pell grants exceed max.', function() {
+    financials.pell = 9999;
+    expect( debtCalc( financials ).errors ).property( 'pellOverCap' );
+  });
+
+  it( '...reports an error when Perkins loan exceeds costs.', function() {
+    financials.pell = 0;
+    financials.perkins = 2;
+    expect( debtCalc( financials ).errors ).property( 'perkinsOverCost' );
+  });
+
+  it( '...reports an error when Perkins loan exceeds federal limit.', function() {
+    financials.tuitionFees = 99999;
+    financials.perkins = 99999;
+    expect( debtCalc( financials ).errors ).property( 'perkinsOverCap' );
+  });
+
+  it( '...reports an error when military tuition assistance exceeds federal limit.', function() {
+    financials.perkins = 0;
+    financials.militaryTuitionAssistance = 99999;
+    expect( debtCalc( financials ).errors ).property( 'mtaOverCap' );
+  });
+
+  it( '...reports an error when subsidized loans exceeds costs.', function() {
+    financials.perkins = 0;
+    financials.tuitionFees = 0;
+    financials.directSubsidized = 99999;
+    expect( debtCalc( financials ).errors ).property( 'subsidizedOverCost' );
+  });
+
+  it( '...reports an error when subsidized loans exceeds federal limit.', function() {
+    financials.yearInCollege = 1;
+    expect( debtCalc( financials ).errors ).property( 'subsidizedOverCap' );
+  });
+
+  it( '...reports an error when unsubsidized loans exceeds costs.', function() {
+    financials.directSubsidized = 0;
+    financials.directUnsubsidized = 99999;
+    expect( debtCalc( financials ).errors ).property( 'unsubsidizedOverCost' );
+  });
+
+  it( '...reports an error when unsubsidized loans exceeds federal limit.', function() {
+    expect( debtCalc( financials ).errors ).property( 'unsubsidizedOverCost' );
+  });
+
+});

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -65,26 +65,26 @@ describe( 'overall debt calculations', function() {
   it( '...calculates Direct subsidized loans.', function() {
     financials.perkins = 0;
     financials.directSubsidized = 3500;
-    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 14150 );
+    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 14000 );
   });
 
   it( '...enforces Direct subsidized loan limit.', function() {
     financials.perkins = 0;
     financials.directSubsidized = 999999;
     debtCalc( financials );
-    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 14150 );
+    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 14000 );
   });
 
   it( '...calculates Direct unsubsidized loans.', function() {
     financials.directSubsidized = 0;
     financials.directUnsubsidized = 9500;
-    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 43777 );
+    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 43312 );
   });
 
   it( '...enforces Direct unsubsidized loan limit.', function() {
     financials.directSubsidized = 0;
     financials.directUnsubsidized = 999999;
-    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 43777 );
+    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 43312 );
   });
 
   it( '...properly calculates multiple loans.', function() {
@@ -93,7 +93,7 @@ describe( 'overall debt calculations', function() {
     financials.directUnsubsidized = 3000;
     financials.institutionalLoan = 1500;
     financials.privateLoan = 2500;
-    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 44280 );
+    expect( Math.floor( debtCalc( financials ).totalDebt ) ).to.equal( 44047 );
   });
 
   it( '...properly calculates remainingCost.', function() {

--- a/test/payment-spec.js
+++ b/test/payment-spec.js
@@ -1,0 +1,64 @@
+var payment = require( '../src/payment' );
+var data = require( '../src/default-values' );
+var calcDebt = require( '../src/calc-debt.js' );
+
+var chai = require('chai');
+var expect = chai.expect;
+
+describe( 'payment calculator', function() {
+
+  it( 'calculates the cost of loans over the lifetime of the loan', function() {
+    data.programLength = 2;
+    data.perkinsDebt = 2000;
+    data.directSubsidizedDebt = 0;
+    data.directUnsubsidizedDebt = 0;
+    data.gradPlusDebt = 0;
+    data.privateLoanTotal = 0;
+    data.institutionalLoanDebt = 0;
+    data.perkinsLoanRate = .05;
+    data.privateLoanMulti = [];
+    data.privateLoan = 0;
+    data.privateLoanDebt = 0;
+
+    payment( data );
+    expect( Math.round( data.loanLifetime ) ).to.equal( 2546 );
+
+    data.directSubsidizedDebt = 4000 * 1.01073;
+    data.subsidizedRate = 0.0466;
+    payment( data );
+    expect( Math.round( data.loanLifetime ) ).to.equal( 7611 );
+
+    data.directUnsubsidizedWithFee = 3000 * 1.01073;
+    data.unsubsidizedRate = 0.0466;
+    data.deferPeriod = 6;
+    data.directUnsubsidizedDebt = calcDebt(
+      data.directUnsubsidizedWithFee,
+      data.unsubsidizedRate,
+      data.programLength,
+      data.deferPeriod
+    );
+    payment( data );
+    expect( Math.round( data.loanLifetime ) ).to.equal( 15918 );
+
+    data.institutionalLoan = 1500;
+    data.institutionalLoanRate = 0.079;
+    data.institutionalLoanDebt = calcDebt(
+      data.institutionalLoan,
+      data.institutionalLoanRate,
+      data.programLength,
+      data.deferPeriod
+    );   
+    payment( data );
+    expect( Math.round( data.loanLifetime ) ).to.equal( 20953 );
+
+    data.perkinsDebt = 0;
+    data.directSubsidizedDebt = 0;
+    data.directUnsubsidizedDebt = 0;
+    data.institutionalLoanDebt = 0;
+    data.privateLoanMulti = [ { amount: 5000, fees: 0, rate: 0.079, deferPeriod: 0, totalDebt: 11580 } ];
+    payment( data );
+    expect( Math.round( data.loanLifetime ) ).to.equal( 16786 );
+  });
+
+
+});


### PR DESCRIPTION
This PR addresses the fees on federal loans. Previously, this package added those fees to the total debt. However, this is not correct - the fees are not added to the debt. This PR removes the fees from these calculations. This PR also addresses the corresponding test values.

This PR is a revisitation of https://github.com/cfpb/student-debt-calculator/pull/22
## Changes
- Federal loan debts no longer include fees.
## Testing
- Pull this down and check out the code. Unit tests were updated, so `npm test` (or `mocha test`) should give you all passing!
## Review
- @ascott1 and @marteki and @niqjohnson and @higs4281 and @saintsoup52 and anyone who has time!
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
