### PR TITLE
10 and 25 Year Loan Value Objects added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 2.4.0 2016-05-18
+- Added the tenYear and twentyFiveYear properties to the returned object
+
 ## 2.3.1 2016-05-17
 - Updated federal interest rates
 - Added error handling for various loan and grant limits

--- a/README.md
+++ b/README.md
@@ -122,30 +122,61 @@ These properties give the calculator caps and maximums on certain values.
 |`financials.perkinsUnderCap` | number | Cap on undergratuate Perkins loans | 5500 |
 |`financials.perkinsGradCap` | number | Cap on graduate Perkins loans | 8000 |
 
+### Outputs
+These properties are added to the returned Object and would generally be
+considered the "outputs" for the package. 
+
+| Property | Type | Description |
+|-----|-----|-----|
+|`financials.firstYearNetCost`| number | The cost of attendance minus grants and scholarships |
+|`financials.moneyForCollege`| number | The total of grants, scholarships, and loans |
+|`financials.remainingCost`| number | The costs of attendance minus all grants, scholarships, and loans |
+|`financials.moneyForCollege`| number | The total of grants, scholarships, and loans |
+|`financials.loanMonthly`| number | The monthly loan payment based on the loans specified and `financials.repaymentTerm`|
+|`financials.loanLifetime`| number | The lifetime cost of the loans based on the loans specified and `financials.repaymentTerm`|
+
+#### tenYear and twentyFiveYear properties
+To make it easy to compare the difference between 10 and 25 year loan repayment terms,
+the Object returned by the package has two additional properties - `financials.tenYear`
+and `financials.twentyFiveYear`. These properties are Objects themselves with their own
+`loanLifetime` and associated values:
+
+| Property | Type | Description |
+|-----|-----|-----|
+|`financials.tenYear.loanMonthly`| number | The monthly loan payment with a 10 year repayment term |
+|`financials.tenYear.loanLifetime`| number | The lifetime cost of the loans with a 10 year repayment term |
+|`financials.twentyFiveYear.loanMonthly`| number | The monthly loan payment with a 25 year repayment term|
+|`financials.twentyFiveYear.loanLifetime`| number | The lifetime cost of the loan with a 25 year repayment term|
+
 ### Calculations, Caps, and Errors
-When applied to the "financials" Object, the package first establishes some constants and determines
-which values should be used for a variety of numbers - for instance, based on whether the program
-is undergraduate or graduate, what the limits of some federal loans are.
 
-The package then establishes scholarships and grants, checking against caps, and calculates the
-`firstYearNetCost` property based on those values (applying the grants and scholarships against the
-cost of attendance).
+When applied to the "financials" Object, the package first establishes some
+constants and determines which values should be used for a variety of numbers
+- for instance, based on whether the program is undergraduate or graduate,
+what the limits of some federal loans are.
 
-Then, the package applies loans to the remaining cost, ensuring these values are below the 
-limits for federal loans.
+The package then establishes scholarships and grants, checking against caps,
+and calculates the `firstYearNetCost` property based on those values (applying
+the grants and scholarships against the cost of attendance).
 
-After grants, scholarships, and loans are applied, the package determines the total money for college
-(`moneyForCollege` property) and the amount left to pay (`remainingCost` property).
+Then, the package applies loans to the remaining cost, ensuring these values
+are below the  limits for federal loans.
 
-Finally, the package calculates the debt at graduation (properties such as `perkinsDebt` or 
-`privateLoanDebt`), the cost of the loans over the repayment term (`loanLifetime` property) and
-the monthly payment of the loans ('loanMonthly' property)
+After grants, scholarships, and loans are applied, the package determines the
+total money for college (`moneyForCollege` property) and the amount left to
+pay (`remainingCost` property).
 
-Along the way, the package also records and corrects "errors" - for instance, when the inputs
-exceed federal limits or the cost of attendance (in which case the values for these inputs are
-changed to equal the limit). These errors can be found in the `errors` property,
-which is an Object itself. The following table illustrates the "error codes" which are used as
-keys in the `errors` Object:
+Finally, the package calculates the debt at graduation (properties such as
+`perkinsDebt` or `privateLoanDebt`), the cost of the loans over the repayment
+term (`loanLifetime` property) and the monthly payment of the loans
+('loanMonthly' property)
+
+Along the way, the package also records and corrects "errors" - for instance,
+when the inputs exceed federal limits or the cost of attendance (in which case
+the values for these inputs are changed to equal the limit). These errors can
+be found in the `errors` property, which is an Object itself. The following
+table illustrates the "error codes" which are used as keys in the `errors`
+Object:
 
 | `errors` Object key | Error |
 |-----|-----|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "student-debt-calc",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Student debt calculator",
   "main": "src/index.js",
   "scripts": {

--- a/src/payment.js
+++ b/src/payment.js
@@ -35,33 +35,33 @@ var payment = {
   },
 
   calculateParentMonthly: function( data, repaymentTerm ) {
-    // loanMonthlyparent
-    var loanMonthlyparent = data.parentPlus * ( data.parentPlusRate / 12 ) /
+    // loanMonthlyParent
+    var loanMonthlyParent = data.parentPlus * ( data.parentPlusRate / 12 ) /
         Math.pow( 1 - ( 1 + data.parentPlusRate / 12 ), -repaymentTerm * 12 ) +
         data.homeEquity * ( data.homeEquityLoanRate / 12 ) /
         Math.pow( 1 - ( 1 + data.homeEquityLoanRate / 12 ), -repaymentTerm * 12 );
-    return loanMonthlyparent;
+    return loanMonthlyParent;
   },
 
   payment: function( data ) {
     // Calculate based on data.repaymentTerm field (legacy support)
     data.loanMonthly = payment.calculateMonthly( data, data.repaymentTerm );
     data.loanLifetime = payment.calculateLifetime( data.loanMonthly, data.repaymentTerm );
-    data.loanMonthlyparent = payment.calculateParentMonthly( data, data.repaymentTerm );
+    data.loanMonthlyParent = payment.calculateParentMonthly( data, data.repaymentTerm );
 
     // Calculate 10 year values
     data.tenYear = {};
     data.tenYear.loanMonthly = payment.calculateMonthly( data, 10 );
     data.tenYear.loanLifetime =
       payment.calculateLifetime( data.tenYear.loanMonthly, 10 );
-    data.tenYear.loanMonthlyparent = payment.calculateParentMonthly( data, 10 );
+    data.tenYear.loanMonthlyParent = payment.calculateParentMonthly( data, 10 );
 
     // Calculate 25 year values
     data.twentyFiveYear = {};
     data.twentyFiveYear.loanMonthly = payment.calculateMonthly( data, 25 );
     data.twentyFiveYear.loanLifetime =
       payment.calculateLifetime( data.twentyFiveYear.loanMonthly, 25 );
-    data.twentyFiveYear.loanMonthlyparent = payment.calculateParentMonthly( data, 25 );
+    data.twentyFiveYear.loanMonthlyParent = payment.calculateParentMonthly( data, 25 );
 
     return data;
   }

--- a/src/payment.js
+++ b/src/payment.js
@@ -5,32 +5,65 @@
   * @param { object } data - the data object
   * @returns { object } the data object with monthly and total payments
   */
-function payment( data ) {
-  // loanMonthly - "Monthly Payments"
-  data.loanMonthly = data.perkinsDebt * ( data.perkinsRate / 12 ) / ( 1 - Math.pow( 1 + data.perkinsRate / 12, -data.repaymentTerm * 12 ) ) +
-  data.directSubsidizedDebt * ( data.subsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.subsidizedRate / 12, -data.repaymentTerm * 12 ) ) +
-  data.directUnsubsidizedDebt * ( data.unsubsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.unsubsidizedRate / 12, -data.repaymentTerm * 12 ) ) +
-  data.gradPlusDebt * ( data.gradPlusRate / 12 ) / ( 1 - Math.pow( 1 + data.gradPlusRate / 12, -data.repaymentTerm * 12 ) ) +
-  data.institutionalLoanDebt * ( data.institutionalLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.institutionalLoanRate / 12, -data.repaymentTerm * 12 ) );
 
-  // Private Loan handler
-  if ( data.privateLoanMulti.length !== 0 ) {
-    for ( var x = 0; x < data.privateLoanMulti.length; x++ ) {
-      var privLoan = data.privateLoanMulti[x];
-      data.loanMonthly += privLoan.totalDebt * ( privLoan.rate / 12 ) / ( 1 - Math.pow( 1 + privLoan.rate / 12, -data.repaymentTerm * 12 ) );
+var payment = {
+
+  calculateMonthly: function( data, repaymentTerm ) {
+    // loanMonthly - "Monthly Payments"
+    var loanMonthly = data.perkinsDebt * ( data.perkinsRate / 12 ) / ( 1 - Math.pow( 1 + data.perkinsRate / 12, -repaymentTerm * 12 ) ) +
+      data.directSubsidizedDebt * ( data.subsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.subsidizedRate / 12, -repaymentTerm * 12 ) ) +
+      data.directUnsubsidizedDebt * ( data.unsubsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.unsubsidizedRate / 12, -repaymentTerm * 12 ) ) +
+      data.gradPlusDebt * ( data.gradPlusRate / 12 ) / ( 1 - Math.pow( 1 + data.gradPlusRate / 12, -repaymentTerm * 12 ) ) +
+      data.institutionalLoanDebt * ( data.institutionalLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.institutionalLoanRate / 12, -repaymentTerm * 12 ) );
+
+    // Private Loan handler
+    if ( data.privateLoanMulti.length !== 0 ) {
+      for ( var x = 0; x < data.privateLoanMulti.length; x++ ) {
+        var privLoan = data.privateLoanMulti[x];
+        loanMonthly += privLoan.totalDebt * ( privLoan.rate / 12 ) / ( 1 - Math.pow( 1 + privLoan.rate / 12, -repaymentTerm * 12 ) );
+      }
+    } else {
+      loanMonthly += data.privateLoanDebt * ( data.privateLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.privateLoanRate / 12, -repaymentTerm * 12 ) );
     }
-  } else {
-    data.loanMonthly += data.privateLoanDebt * ( data.privateLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.privateLoanRate / 12, -data.repaymentTerm * 12 ) );
+    return loanMonthly;
+  },
+
+  calculateLifetime: function( data, repaymentTerm ) {
+    // loanLifetime
+    var loanLifetime = data.loanMonthly * repaymentTerm * 12;
+    return loanLifetime;
+  },
+
+  calculateParentMonthly: function( data, repaymentTerm ) {
+    // loanMonthlyparent
+    var loanMonthlyparent = data.parentPlus * ( data.parentPlusRate / 12 ) /
+        Math.pow( 1 - ( 1 + data.parentPlusRate / 12 ), -repaymentTerm * 12 ) +
+        data.homeEquity * ( data.homeEquityLoanRate / 12 ) /
+        Math.pow( 1 - ( 1 + data.homeEquityLoanRate / 12 ), -repaymentTerm * 12 );
+    return loanMonthlyparent;
+  },
+
+  payment: function( data ) {
+    // Calculate based on data.repaymentTerm field (legacy support)
+    data.loanMonthly = payment.calculateMonthly( data, data.repaymentTerm );
+    data.loanLifetime = payment.calculateLifetime( data, data.repaymentTerm );
+    data.loanMonthlyparent = payment.calculateParentMonthly( data, data.repaymentTerm );
+
+    // Calculate 10 year values
+    data.tenYear = {};
+    data.tenYear.loanMonthly = payment.calculateMonthly( data, 10 );
+    data.tenYear.loanLifetime = payment.calculateLifetime( data, 10 );
+    data.tenYear.loanMonthlyparent = payment.calculateParentMonthly( data, 10 );
+
+    // Calculate 25 year values
+    data.twentyFiveYear = {};
+    data.twentyFiveYear.loanMonthly = payment.calculateMonthly( data, 25 );
+    data.twentyFiveYear.loanLifetime = payment.calculateLifetime( data, 25 );
+    data.twentyFiveYear.loanMonthlyparent = payment.calculateParentMonthly( data, 25 );
+
+    return data;
   }
 
-  // loanMonthlyparent
-  data.loanMonthlyparent = data.parentPlus * ( data.parentPlusRate / 12 ) / Math.pow( 1 - ( 1 + data.parentPlusRate / 12 ), -data.repaymentTerm * 12 ) +
-      data.homeEquity * ( data.homeEquityLoanRate / 12 ) / Math.pow( 1 - ( 1 + data.homeEquityLoanRate / 12 ), -data.repaymentTerm * 12 );
+};
 
-  // loanLifetime
-  data.loanLifetime = data.loanMonthly * data.repaymentTerm * 12;
-
-  return data;
-}
-
-module.exports = payment;
+module.exports = payment.payment;

--- a/src/payment.js
+++ b/src/payment.js
@@ -52,14 +52,14 @@ var payment = {
     // Calculate 10 year values
     data.tenYear = {};
     data.tenYear.loanMonthly = payment.calculateMonthly( data, 10 );
-    data.tenYear.loanLifetime = 
+    data.tenYear.loanLifetime =
       payment.calculateLifetime( data.tenYear.loanMonthly, 10 );
     data.tenYear.loanMonthlyparent = payment.calculateParentMonthly( data, 10 );
 
     // Calculate 25 year values
     data.twentyFiveYear = {};
     data.twentyFiveYear.loanMonthly = payment.calculateMonthly( data, 25 );
-    data.twentyFiveYear.loanLifetime = 
+    data.twentyFiveYear.loanLifetime =
       payment.calculateLifetime( data.twentyFiveYear.loanMonthly, 25 );
     data.twentyFiveYear.loanMonthlyparent = payment.calculateParentMonthly( data, 25 );
 

--- a/src/payment.js
+++ b/src/payment.js
@@ -10,27 +10,27 @@ var payment = {
 
   calculateMonthly: function( data, repaymentTerm ) {
     // loanMonthly - "Monthly Payments"
-    var loanMonthly = data.perkinsDebt * ( data.perkinsRate / 12 ) / ( 1 - Math.pow( 1 + data.perkinsRate / 12, -repaymentTerm * 12 ) ) +
-      data.directSubsidizedDebt * ( data.subsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.subsidizedRate / 12, -repaymentTerm * 12 ) ) +
-      data.directUnsubsidizedDebt * ( data.unsubsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.unsubsidizedRate / 12, -repaymentTerm * 12 ) ) +
-      data.gradPlusDebt * ( data.gradPlusRate / 12 ) / ( 1 - Math.pow( 1 + data.gradPlusRate / 12, -repaymentTerm * 12 ) ) +
-      data.institutionalLoanDebt * ( data.institutionalLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.institutionalLoanRate / 12, -repaymentTerm * 12 ) );
+    var loanMonthly = data.perkinsDebt * ( data.perkinsRate / 12 ) / ( 1 - Math.pow( 1 + data.perkinsRate / 12, -1 * repaymentTerm * 12 ) ) +
+      data.directSubsidizedDebt * ( data.subsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.subsidizedRate / 12, -1 * repaymentTerm * 12 ) ) +
+      data.directUnsubsidizedDebt * ( data.unsubsidizedRate / 12 ) / ( 1 - Math.pow( 1 + data.unsubsidizedRate / 12, -1 * repaymentTerm * 12 ) ) +
+      data.gradPlusDebt * ( data.gradPlusRate / 12 ) / ( 1 - Math.pow( 1 + data.gradPlusRate / 12, -1 * repaymentTerm * 12 ) ) +
+      data.institutionalLoanDebt * ( data.institutionalLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.institutionalLoanRate / 12, -1 * repaymentTerm * 12 ) );
 
     // Private Loan handler
     if ( data.privateLoanMulti.length !== 0 ) {
       for ( var x = 0; x < data.privateLoanMulti.length; x++ ) {
         var privLoan = data.privateLoanMulti[x];
-        loanMonthly += privLoan.totalDebt * ( privLoan.rate / 12 ) / ( 1 - Math.pow( 1 + privLoan.rate / 12, -repaymentTerm * 12 ) );
+        loanMonthly += privLoan.totalDebt * ( privLoan.rate / 12 ) / ( 1 - Math.pow( 1 + privLoan.rate / 12, -1 * repaymentTerm * 12 ) );
       }
     } else {
-      loanMonthly += data.privateLoanDebt * ( data.privateLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.privateLoanRate / 12, -repaymentTerm * 12 ) );
+      loanMonthly += data.privateLoanDebt * ( data.privateLoanRate / 12 ) / ( 1 - Math.pow( 1 + data.privateLoanRate / 12, -1 * repaymentTerm * 12 ) );
     }
     return loanMonthly;
   },
 
-  calculateLifetime: function( data, repaymentTerm ) {
+  calculateLifetime: function( loanMonthly, repaymentTerm ) {
     // loanLifetime
-    var loanLifetime = data.loanMonthly * repaymentTerm * 12;
+    var loanLifetime = loanMonthly * repaymentTerm * 12;
     return loanLifetime;
   },
 
@@ -46,19 +46,21 @@ var payment = {
   payment: function( data ) {
     // Calculate based on data.repaymentTerm field (legacy support)
     data.loanMonthly = payment.calculateMonthly( data, data.repaymentTerm );
-    data.loanLifetime = payment.calculateLifetime( data, data.repaymentTerm );
+    data.loanLifetime = payment.calculateLifetime( data.loanMonthly, data.repaymentTerm );
     data.loanMonthlyparent = payment.calculateParentMonthly( data, data.repaymentTerm );
 
     // Calculate 10 year values
     data.tenYear = {};
     data.tenYear.loanMonthly = payment.calculateMonthly( data, 10 );
-    data.tenYear.loanLifetime = payment.calculateLifetime( data, 10 );
+    data.tenYear.loanLifetime = 
+      payment.calculateLifetime( data.tenYear.loanMonthly, 10 );
     data.tenYear.loanMonthlyparent = payment.calculateParentMonthly( data, 10 );
 
     // Calculate 25 year values
     data.twentyFiveYear = {};
     data.twentyFiveYear.loanMonthly = payment.calculateMonthly( data, 25 );
-    data.twentyFiveYear.loanLifetime = payment.calculateLifetime( data, 25 );
+    data.twentyFiveYear.loanLifetime = 
+      payment.calculateLifetime( data.twentyFiveYear.loanMonthly, 25 );
     data.twentyFiveYear.loanMonthlyparent = payment.calculateParentMonthly( data, 25 );
 
     return data;

--- a/test/payment-spec.js
+++ b/test/payment-spec.js
@@ -22,13 +22,17 @@ describe( 'payment calculator', function() {
 
     payment( data );
     expect( Math.round( data.loanLifetime ) ).to.equal( 2546 );
+    expect( Math.round( data.tenYear.loanLifetime ) ).to.equal( 2546 );
+    expect( Math.round( data.twentyFiveYear.loanLifetime ) ).to.equal( 3508 );
 
-    data.directSubsidizedDebt = 4000 * 1.01073;
+    data.directSubsidizedDebt = 4000;
     data.subsidizedRate = 0.0466;
     payment( data );
-    expect( Math.round( data.loanLifetime ) ).to.equal( 7611 );
+    expect( Math.round( data.loanLifetime ) ).to.equal( 7557 );
+    expect( Math.round( data.tenYear.loanLifetime ) ).to.equal( 7557 );
+    expect( Math.round( data.twentyFiveYear.loanLifetime ) ).to.equal( 10287 );
 
-    data.directUnsubsidizedWithFee = 3000 * 1.01073;
+    data.directUnsubsidizedWithFee = 1500;
     data.unsubsidizedRate = 0.0466;
     data.deferPeriod = 6;
     data.directUnsubsidizedDebt = calcDebt(
@@ -38,7 +42,9 @@ describe( 'payment calculator', function() {
       data.deferPeriod
     );
     payment( data );
-    expect( Math.round( data.loanLifetime ) ).to.equal( 15918 );
+    expect( Math.round( data.loanLifetime ) ).to.equal( 11666 );
+    expect( Math.round( data.tenYear.loanLifetime ) ).to.equal( 11666 );
+    expect( Math.round( data.twentyFiveYear.loanLifetime ) ).to.equal( 15845 );
 
     data.institutionalLoan = 1500;
     data.institutionalLoanRate = 0.079;
@@ -49,15 +55,15 @@ describe( 'payment calculator', function() {
       data.deferPeriod
     );   
     payment( data );
-    expect( Math.round( data.loanLifetime ) ).to.equal( 20953 );
+    expect( Math.round( data.loanLifetime ) ).to.equal( 16702 );
+    expect( Math.round( data.tenYear.loanLifetime ) ).to.equal( 16702 );
+    expect( Math.round( data.twentyFiveYear.loanLifetime ) ).to.equal( 23820 );
 
-    data.perkinsDebt = 0;
-    data.directSubsidizedDebt = 0;
-    data.directUnsubsidizedDebt = 0;
-    data.institutionalLoanDebt = 0;
     data.privateLoanMulti = [ { amount: 5000, fees: 0, rate: 0.079, deferPeriod: 0, totalDebt: 11580 } ];
     payment( data );
-    expect( Math.round( data.loanLifetime ) ).to.equal( 16786 );
+    expect( Math.round( data.loanLifetime ) ).to.equal( 33489 );
+    expect( Math.round( data.tenYear.loanLifetime ) ).to.equal( 33489 );
+    expect( Math.round( data.twentyFiveYear.loanLifetime ) ).to.equal( 50404 );
   });
 
 


### PR DESCRIPTION
(This pull request supersedes https://github.com/cfpb/student-debt-calculator/pull/24)

This PR adds outputs that reflect 10 and 25 year loan values. This will make it easier for applications to compare the two without running this package multiple times. This updates the version to 2.4.0 - this change shouldn't break any existing implementations of the code. 
## Additions
- The returned Object has two new properties, `tenYear` and `twentyYear`, which themselves are Objects containing their own values like `loanLifetime` and `loanMonthly`
- Adds `nyc` for test coverage
## Testing
- Pull it down, run `npm install`, and check it out. The `test/payment-spec.js` file contains new `expect()` functions that check the new values.
## Review
- @ascott1 (if you have time), @marteki, @higs4281,@niqjohnson - feel free to contact me to walk you through it!
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated GIF

![liz-lemon-self-high5](https://cloud.githubusercontent.com/assets/1490703/15291693/3b5becf4-1b4d-11e6-9686-cb763dd57899.gif)
