### PR TITLE
Parent PLUS fix, version 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ These values are deducted from cost of attendance.
 |`financials.workstudy` | number | Value of work-study | 0 |
 |`financials.savings` | number | Total personal savings to be spent to reduce annual cost of attendance | 0 |
 |`financials.family` | number | Total family contributions to be spent to reduce annual cost of attendance | 0 |
+|`financials.parentPlus` | number | Federal Parent PLUS loan amount (the interest for this loan is not added to student loan totals, but is calculated as a monthly payment in outputs as `financials.loanMonthlyParent`) | 0 |
 
 #### Federal Loans
 
@@ -134,6 +135,7 @@ considered the "outputs" for the package.
 |`financials.moneyForCollege`| number | The total of grants, scholarships, and loans |
 |`financials.loanMonthly`| number | The monthly loan payment based on the loans specified and `financials.repaymentTerm`|
 |`financials.loanLifetime`| number | The lifetime cost of the loans based on the loans specified and `financials.repaymentTerm`|
+|`financials.loanMonthlyParent`| number | The monthly loan payment of the federal Parent PLUS loan.|
 
 #### tenYear and twentyFiveYear properties
 To make it easy to compare the difference between 10 and 25 year loan repayment terms,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "student-debt-calc",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Student debt calculator",
   "main": "src/index.js",
   "scripts": {

--- a/src/scholarship.js
+++ b/src/scholarship.js
@@ -45,6 +45,7 @@ function scholarships( data ) {
   data.savingsTotal = data.savings +
                       data.family +
                       data.state529plan +
+                      data.parentPlus +
                       data.workstudy;
 
   // Total grants and savings

--- a/test/scholarship-spec.js
+++ b/test/scholarship-spec.js
@@ -47,7 +47,8 @@ describe( 'set scholarship and grant values', function() {
   it( 'calculates total contributions', function() {
     data.undergrad = true;
     data.savings = 10000;
-    data.family = 4400;
+    data.family = 2400;
+    data.parentPlus = 2000;
     data.state529plan = 2000;
     data.workstudy = 2000;
     scholarship( data );


### PR DESCRIPTION
This PR puts the 'parentPlus' property into the calculations. I'm treating this change as a bug fix rather than a feature addition (thus, it updates to version `2.4.1`).

Parent PLUS loans are meant to be treated as 'contributions' which subtract from costs, but unlike other loans, the interest is not added to the student loan totals in outputs. Rather, Parent PLUS loans are calculated as a special output property, 'loanMonthlyParent'.
## Changes
- The `parentPlus` property is now counted as a contribution, and reduces cost.
- `README.md` updated with `parentPlus` and `loanMonthlyParent`
## Testing
- Pull it down and try it out
- `npm test` is all passing (and I changed a test to put `parentPlus` into calculations)
## Review
- @marteki or @niqjohnson or @higs4281 or anyone who has time!
## Todos
- I noticed there is some legacy code for home equity loans which is lurking in this package - I have no removed them, but I will determine whether or not we want to keep it (and add it to the actual cost calculations) or remove it from the codebase.
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices 
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
## Animated GIF

![groucho-dance](https://cloud.githubusercontent.com/assets/1490703/15507404/794ae3c4-2199-11e6-87ec-e55e96b8fc41.gif)
